### PR TITLE
seclabel healthd added to service battery_charger.

### DIFF
--- a/ramdisk/init.universal5433.rc
+++ b/ramdisk/init.universal5433.rc
@@ -632,6 +632,7 @@ service ipsec-daemon /system/bin/IPSecService
 service battery_charger /sbin/healthd -c
     class charger
     critical
+    seclabel u:r:healthd:s0
 
 # LPM
 on property:ro.bootmode=charger


### PR DESCRIPTION
This allows charging when the device is off. Otherwise the battery_charger
service has no permission to execute and the device will boot into recovery mode.
